### PR TITLE
Fix OpenAI 'max_tokens' error

### DIFF
--- a/.github/workflows/daily-news.yml
+++ b/.github/workflows/daily-news.yml
@@ -70,6 +70,11 @@ jobs:
           # Optional: Webhook
           WEBHOOK_URL: ${{ secrets.WEBHOOK_URL }}
 
+          # Optional: Discord
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          DISCORD_USERNAME: ${{ secrets.DISCORD_USERNAME }}
+          DISCORD_AVATAR_URL: ${{ secrets.DISCORD_AVATAR_URL }}
+
           # Optional: Language (defaults to 'en' if not set)
           # Supported: en, zh, es, fr, ja, de, ko, pt, ru, ar, hi, it, nl
           # For multiple languages, separate with commas (e.g., 'en,zh,ja')

--- a/src/llm_providers/openai_provider.py
+++ b/src/llm_providers/openai_provider.py
@@ -73,7 +73,7 @@ class OpenAIProvider(BaseLLMProvider):
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                max_tokens=max_tokens,
+                max_completion_tokens=max_tokens,
                 temperature=temperature,
                 **kwargs
             )
@@ -125,7 +125,7 @@ class OpenAIProvider(BaseLLMProvider):
                     model=self.model,
                     messages=messages,
                     tools=tools,
-                    max_tokens=max_tokens,
+                    max_completion_tokens=max_tokens,
                     **kwargs
                 )
 

--- a/src/notifiers/discord_notifier.py
+++ b/src/notifiers/discord_notifier.py
@@ -30,9 +30,9 @@ class DiscordNotifier:
             avatar_url: Optional bot avatar URL
             timeout: Request timeout in seconds
         """
-        self.webhook_url = webhook_url or os.getenv("DISCORD_WEBHOOK_URL")
-        self.username = username or os.getenv("DISCORD_USERNAME", "AI News Bot")
-        self.avatar_url = avatar_url or os.getenv("DISCORD_AVATAR_URL")
+        self.webhook_url = webhook_url or os.getenv("DISCORD_WEBHOOK_URL") or None
+        self.username = username or os.getenv("DISCORD_USERNAME") or "AI News Bot"
+        self.avatar_url = avatar_url or os.getenv("DISCORD_AVATAR_URL") or None
         self.timeout = timeout
 
         if not self.webhook_url:

--- a/src/notifiers/discord_notifier.py
+++ b/src/notifiers/discord_notifier.py
@@ -214,18 +214,62 @@ class DiscordNotifier:
 
         return sections
 
-    def _batch_embeds(self, embeds: List[Dict[str, Any]], batch_size: int = 10) -> List[List[Dict[str, Any]]]:
+    @staticmethod
+    def _embed_length(embed: Dict[str, Any]) -> int:
         """
-        Batch embeds to respect Discord's limit of 10 embeds per message.
+        Compute an embed's character length the way Discord counts it
+        toward the 6000-char-per-message total.
+        """
+        length = 0
+        length += len(embed.get("title", "") or "")
+        length += len(embed.get("description", "") or "")
+        footer = embed.get("footer") or {}
+        length += len(footer.get("text", "") or "")
+        author = embed.get("author") or {}
+        length += len(author.get("name", "") or "")
+        for field in embed.get("fields", []) or []:
+            length += len(field.get("name", "") or "")
+            length += len(field.get("value", "") or "")
+        return length
+
+    def _batch_embeds(
+        self,
+        embeds: List[Dict[str, Any]],
+        batch_size: int = 10,
+        max_total_chars: int = 6000,
+    ) -> List[List[Dict[str, Any]]]:
+        """
+        Batch embeds to respect Discord's limits: at most 10 embeds per
+        message AND at most 6000 characters summed across all embeds in a
+        single message.
 
         Args:
             embeds: List of all embeds
             batch_size: Maximum embeds per batch (Discord limit is 10)
+            max_total_chars: Maximum summed embed chars per batch (Discord limit is 6000)
 
         Returns:
             List of embed batches
         """
-        batches = []
-        for i in range(0, len(embeds), batch_size):
-            batches.append(embeds[i:i + batch_size])
+        batches: List[List[Dict[str, Any]]] = []
+        current: List[Dict[str, Any]] = []
+        current_chars = 0
+
+        for embed in embeds:
+            embed_chars = self._embed_length(embed)
+
+            if current and (
+                len(current) >= batch_size
+                or current_chars + embed_chars > max_total_chars
+            ):
+                batches.append(current)
+                current = []
+                current_chars = 0
+
+            current.append(embed)
+            current_chars += embed_chars
+
+        if current:
+            batches.append(current)
+
         return batches


### PR DESCRIPTION
Hi. Thank you for this awesome project.

### Problem
I just noticed that when I choose openai as LLM provider, the workflow fails with the following error.

```
***.BadRequestError: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

This is because the current source code uses `max_tokens` when building openai client, which is deprecated.
(https://github.com/giftedunicorn/ai-news-bot/issues/12 addresses the same issue.)

### Fix

- I changed `max_tokens` to `max_completion_tokens`, which seems to be the current standard.
- I've tested it in my forked repo and confirmed it working well.
- Resolves #12 