### PR TITLE
Fix OpenAI 'max_tokens' error

### DIFF
--- a/src/llm_providers/openai_provider.py
+++ b/src/llm_providers/openai_provider.py
@@ -73,7 +73,7 @@ class OpenAIProvider(BaseLLMProvider):
             response = self.client.chat.completions.create(
                 model=self.model,
                 messages=messages,
-                max_tokens=max_tokens,
+                max_completion_tokens=max_tokens,
                 temperature=temperature,
                 **kwargs
             )
@@ -125,7 +125,7 @@ class OpenAIProvider(BaseLLMProvider):
                     model=self.model,
                     messages=messages,
                     tools=tools,
-                    max_tokens=max_tokens,
+                    max_completion_tokens=max_tokens,
                     **kwargs
                 )
 


### PR DESCRIPTION
Hi. Thank you for this awesome project.

### Problem
I just noticed that when I choose openai as LLM provider, the workflow fails with the following error.

```
***.BadRequestError: Error code: 400 - {'error': {'message': "Unsupported parameter: 'max_tokens' is not supported with this model. Use 'max_completion_tokens' instead.", 'type': 'invalid_request_error', 'param': 'max_tokens', 'code': 'unsupported_parameter'}}
```

This is because the current source code uses `max_tokens` when building openai client, which is deprecated.
(https://github.com/giftedunicorn/ai-news-bot/issues/12 addresses the same issue.)

### Fix

- I changed `max_tokens` to `max_completion_tokens`, which seems to be the current standard.
- I've tested it in my forked repo and confirmed it working well.
- Resolves #12 